### PR TITLE
メッセージ送信機能を非同期通信にする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,3 +66,4 @@ gem 'font-awesome-sass', '~> 5.11.2'
 gem "devise"
 gem 'carrierwave'
 gem 'mini_magick'
+gem 'jquery-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'coffee-rails', '~> 4.2'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+# gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production
@@ -66,4 +66,3 @@ gem 'font-awesome-sass', '~> 5.11.2'
 gem "devise"
 gem 'carrierwave'
 gem 'mini_magick'
-gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,9 +232,6 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -279,7 +276,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,3 +14,4 @@
 //= require jquery_ujs
 //= require turbolinks
 //= require_tree .
+//= require rails-ujs 

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,52 @@
+$(function(){
+  function buildMessage(message){
+     
+    let image = (message.image) ? `<img class="lower-message__image" src="${message.image}" alt="no_image">` : "";
+    
+    let html = `<div class="message">
+                  <div class="upper-message">
+                    <div class="upper-message__user-name">
+                      ${message.user_name}
+                    </div>
+                    <div class="upper-message__date">
+                      ${message.updated_at}
+                    </div>
+                  </div>
+                  <div class="lower-message">
+                    <p class="lower-message__content">
+                      ${message.content}
+                    </p>
+                      ${image}
+                  </div>
+                </div>`
+    return html;
+  }
+
+  $('#new_message').on('submit', function(e){
+    e.preventDefault();
+    let formData = new FormData(this);
+    let url = $(this).attr('action');
+    $.ajax({
+      url: url,
+      type: 'POST',
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(message){
+      // console.table(message);
+      let html = buildMessage(message);
+      // console.log(html);
+      $('.messages').append(html);
+      // $('#message_content').val('');
+      $("#new_message")[0].reset();
+      $('.form__submit').prop('disabled', false);
+      $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+    })
+    .fail(function(){
+      alert('エラー')
+      $('.form__submit').prop('disabled', false);
+    })
+  })
+});

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -35,11 +35,8 @@ $(function(){
       contentType: false
     })
     .done(function(message){
-      // console.table(message);
       let html = buildMessage(message);
-      // console.log(html);
       $('.messages').append(html);
-      // $('#message_content').val('');
       $("#new_message")[0].reset();
       $('.form__submit').prop('disabled', false);
       $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,11 +9,10 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
-    else
-      @messages = @group.messages.includes(:user)
-      flash.now[:alert] = 'メッセージを入力してください。'
-      render :index
+      respond_to do |format|
+        format.html { redirect_to group_messages_path, notice: "メッセージを送信しました" }
+        format.json
+      end
     end
   end
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,11 @@
     %meta{content: "text/html; charset=UTF-8", "http-equiv": "Content-Type"}/
     %title ChatSpace
     = csrf_meta_tags
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all'
+    = javascript_include_tag 'application'
   %body
     = render 'layouts/notifications'
     = yield
+
+    -# , 'data-turbolinks-track': 'reload'
+    -# , 'data-turbolinks-track': 'reload'

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.content @message.content
+json.image @message.image.url
+json.updated_at @message.updated_at
+json.user_name @message.user.name


### PR DESCRIPTION
# what
・0 新しいブランチを作成する
・1 jsファイルを作成する
・2 フォームが送信されたら、イベントが発火するようにする
・3 2のイベントが発火したときにAjaxを使用して、messages#createが動くようにする
・4 messages#createでメッセージを保存し、respond_toを使用してHTMLとJSONの場合で処理を分ける
・5 jbuilderを使用して、作成したメッセージをJSON形式で返す
・6 返ってきたJSONをdoneメソッドで受取り、HTMLを作成する
・7 6で作成したHTMLをメッセージ画面の一番下に追加する
・8 メッセージを送信したとき、メッセージ画面を最下部にスクロールする
・9 連続で送信ボタンを押せるようにする
・10 非同期に失敗した場合の処理も準備する

# why
本アプリの根幹機能のため